### PR TITLE
fixes #116

### DIFF
--- a/AntWars/AI/AIBase.cs
+++ b/AntWars/AI/AIBase.cs
@@ -116,7 +116,7 @@ namespace AntWars.AI {
         private bool buyAnt(Ant ant) {
             double cost = Helper.CostCalculator.calculateCost(ant);
             Base b = Game.Board.BoardObjects.getBase(Player);
-            if (resolveAntCoords(ant, b) && !Player.pay(cost)) {
+            if (!resolveAntCoords(ant, b) || !Player.pay(cost)) {
                 return false;
             }
             ant.AI = Player.AILoader.createAIAntInstance(ant, Game.Conf);


### PR DESCRIPTION
Falsches if-Statement. Hatte dazu geführt, dass Ants manchmal kein `Coordinates` Objekt in der Property hatten.
